### PR TITLE
Fix typo: Change title 110350 and 110351

### DIFF
--- a/content/notes/wwdc22/110350.md
+++ b/content/notes/wwdc22/110350.md
@@ -2,119 +2,69 @@
 contributors: zntfdr
 ---
 
-## Task isolation
+## Swift Concurrency Recap
 
-- Task isolation ensures that data across tasks is not shared in a manner that can introduce data races
+### `Async/await` 
 
-### Task
+- basic syntactic building blocks for concurrent code
+- allow you to create and call functions that can suspend their work in the middle of execution, then resume that work later, without blocking an execution thread
 
-- A task performs a specific job sequentially from start to finish
-- Tasks are asynchronous, and their work can be suspended any number of times at `await` operations
-- A task is self-contained - has its own resources and can operate by itself, independently of any other task
+### `Task`s
 
-### Communications between tasks
+- basic unit of work in concurrent code
+- execute concurrent code and manage its state and associated data
+- contain local variables
+- handle cancellation
+- begin/suspend execution of async code
 
-- done by passing objects across tasks (a task passes an object by returning a value at the end of its body)
-- no problem if the shared/transferred data is value type
-- can (potentially) cause data races if the data is reference type
+### Structured concurrency
 
-#### Sendable
+- makes it easy to spawn child tasks to run in parallel and wait for them to complete
+- ensures that tasks are awaited or automatically canceled if not used
 
-Swift helps us telling us when it's safe to share our data across tasks via the `Sendable` protocol:
+### `Actor`s
 
-- `Sendable` descibes types that can cross an isolation domain (like tasks), without making data races 
-- data races checks happen while building by the Swift compiler
-- For tasks, the actual `Sendable` constraint comes from their definition: `Task`s return type must conform to `Sendable`
-- You should use `Sendable` constraints where you have generic parameters whose values will be passed across different isolation domains
-- `Sendable` conformances can be inferred by the Swift compiler for non-public types (but you can add `Sendable` conformance explicitly)
-- Classes (reference types) can conform to `Sendable` only under very narrow circumstances
-  - e.g., when a `final` class only has immutable storage
+- coordinate multiple tasks that need to access shared data
+- isolate data from the outside
+- allow only one task at a time to manipulate their internal state, avoiding data races from concurrent mutation
 
-- for reference types that do their own internal synchronization (e.g., via locks), you can use `@unchecked Sendable`
+### `Continuation`s 
 
-```swift
-class ConcurrentCache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendable {
-  var lock: NSLock
-  var storage: [Key: Value]
+- bridge between Swift concurrency and other forms of async code (GCD)
+- a continuation suspends the current task and provides a callback which resumes the task when called
+- can be used with callback-based async APIs
+- Continuation callbacks must be called exactly once
 
-  // ...
-}
-```
+## Concurrency Optimization
 
-## Actor isolation
+Even with Swift concurrency is still possible to write code that misuses concurrency constructs, common issues:
 
-- `Actor`s provide a way to isolate state that can be accessed by different tasks, in a coordinated manner that eliminates data races
-- an `Actor` is self-contained - has its own resources and can operate by itself, independently of any other Actor
-- in order to execute code (or read values) defined in an actor, you need to use a task
-- only one task can execute on an actor at a time
-- entering into an actor is a potential suspension point, as there might be already another task running on it, and even other tasks waiting to enter into that specific actor 
-- the same rules for communications across tasks are true for communication between tasks and actors and between actors
-  - said in other words, actors rely on `Sendable`, too
+### Main actor blocking 
 
-- `Actor`s are reference types, but isolate all of their properties and code to prevent concurrent access
-  - all `Actor` types are implicitly `Sendable`
+- occurs when a long-running task runs on the main Actor
+- can cause your app to hang
 
-- all Actor instance definitions (properties and functions) are isolated
-  - a child/sub task inherits all attributes of the parent task, therefore, if a task is generated directly by an actor function, said task inherits actor isolation from its context (thus will be able to access the actor properties and call other functions without `await`ing on them
-  - the same is not true for detached tasks, which do not inherit traits from that task’s originating context
-  - Actor properties and functions marked as `nonisolated` are considered to be outside the actor
+### Actor contention 
 
-### @MainActor
+- occurs when several tasks attempt to use the same `Actor` simultaneously
+- each task must wait for the Actor to become available
+- the `Actor` serializes execution of those tasks
+- hurt performance by reducing parallel execution
+- To fix this, we need make sure that tasks only run on the Actor when they really need exclusive access to the Actor's data. Everything else should run off of the Actor
 
-- represents main thread
-- use it when you need to update UI in your app
-- use the `@MainActor` attribute to indicate that the code must run on the main actor:
+### Thread pool exhaustion
 
-```swift
-@MainActor func updateView() { … }
+- hurt performance by reducing parallel execution
+- can hurt performance or even deadlock an application
+- happens when a task waits for something via a blocking call, such as blocking file or network IO, or acquiring locks, without suspending
+- this breaks the requirement for tasks to make forward progress, because the task continues to occupy the thread where it's executing, but it isn't actually using a CPU core
+- in such situations the concurrency runtime is unable to fully use all CPU cores, and can even cause deadlock
+- make blocking calls outside Swift Concurrency (for example by running it on a Dispatch queue, and bridge it to the concurrency world using continuations)
 
-Task { @MainActor in
-  // update UI here
-}
-```
+### Continuation misuse
 
-- the Swift compiler will guarantee that main-actor-isolated code will only be executed on the main thread
+- occurs when the continuation callback is called multiple times or never
+- the program will crash or misbehave when the continuation callback is called more than once
+- the task will leak (a.k.a. wait forever) if the callback is never called
 
-- `@MainActor` can also be applied to types, in which case the instances of those types will be isolated to the main actor
-  - properties will be only accessible while on the main actor
-  - methods are isolated to the main actor, unless marked `nonisolated`
-
-```swift
-@MainActor
-class ChickenValley: Sendable {
-  var flock: [Chicken]
-  var food: [Pineapple]
-
-  func advanceTime() {
-    for chicken in flock {
-      chicken.eat(from: &food)
-    }
-  }
-}
-```
-
-## Atomicity
-
-- state can change across `awaits` calls
-- if you're not careful, you can end up with a high-level data race where the program is in an unexpected state, even though the data is not corrupted
-- when writing your actor, think in terms of synchronous, transactional operations that can be interleaved in any way
-- keep async actor operations simple
-
-## Ordering
-
-- Swift Concurrency provides tools for ordering operations
-- actors do no guaranteed FIFO processing
-- actors execute the highest-priority work first
-  - eliminates priority inversions
-  - diffent than serial Dispatch queues, which execute in a strictly FIFO order
-
-Tools for ordering:
-
-- `Task`s
-- `AsyncStream`s deliver elements in order:
-
-```swift
-for await event in eventStream {
-  await process(event)
-}
-```
+The new Swift Concurrency instrument helps catching these problems in your app.

--- a/content/notes/wwdc22/110351.md
+++ b/content/notes/wwdc22/110351.md
@@ -2,69 +2,119 @@
 contributors: zntfdr
 ---
 
-## Swift Concurrency Recap
+## Task isolation
 
-### `Async/await` 
+- Task isolation ensures that data across tasks is not shared in a manner that can introduce data races
 
-- basic syntactic building blocks for concurrent code
-- allow you to create and call functions that can suspend their work in the middle of execution, then resume that work later, without blocking an execution thread
+### Task
 
-### `Task`s
+- A task performs a specific job sequentially from start to finish
+- Tasks are asynchronous, and their work can be suspended any number of times at `await` operations
+- A task is self-contained - has its own resources and can operate by itself, independently of any other task
 
-- basic unit of work in concurrent code
-- execute concurrent code and manage its state and associated data
-- contain local variables
-- handle cancellation
-- begin/suspend execution of async code
+### Communications between tasks
 
-### Structured concurrency
+- done by passing objects across tasks (a task passes an object by returning a value at the end of its body)
+- no problem if the shared/transferred data is value type
+- can (potentially) cause data races if the data is reference type
 
-- makes it easy to spawn child tasks to run in parallel and wait for them to complete
-- ensures that tasks are awaited or automatically canceled if not used
+#### Sendable
 
-### `Actor`s
+Swift helps us telling us when it's safe to share our data across tasks via the `Sendable` protocol:
 
-- coordinate multiple tasks that need to access shared data
-- isolate data from the outside
-- allow only one task at a time to manipulate their internal state, avoiding data races from concurrent mutation
+- `Sendable` descibes types that can cross an isolation domain (like tasks), without making data races 
+- data races checks happen while building by the Swift compiler
+- For tasks, the actual `Sendable` constraint comes from their definition: `Task`s return type must conform to `Sendable`
+- You should use `Sendable` constraints where you have generic parameters whose values will be passed across different isolation domains
+- `Sendable` conformances can be inferred by the Swift compiler for non-public types (but you can add `Sendable` conformance explicitly)
+- Classes (reference types) can conform to `Sendable` only under very narrow circumstances
+  - e.g., when a `final` class only has immutable storage
 
-### `Continuation`s 
+- for reference types that do their own internal synchronization (e.g., via locks), you can use `@unchecked Sendable`
 
-- bridge between Swift concurrency and other forms of async code (GCD)
-- a continuation suspends the current task and provides a callback which resumes the task when called
-- can be used with callback-based async APIs
-- Continuation callbacks must be called exactly once
+```swift
+class ConcurrentCache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendable {
+  var lock: NSLock
+  var storage: [Key: Value]
 
-## Concurrency Optimization
+  // ...
+}
+```
 
-Even with Swift concurrency is still possible to write code that misuses concurrency constructs, common issues:
+## Actor isolation
 
-### Main actor blocking 
+- `Actor`s provide a way to isolate state that can be accessed by different tasks, in a coordinated manner that eliminates data races
+- an `Actor` is self-contained - has its own resources and can operate by itself, independently of any other Actor
+- in order to execute code (or read values) defined in an actor, you need to use a task
+- only one task can execute on an actor at a time
+- entering into an actor is a potential suspension point, as there might be already another task running on it, and even other tasks waiting to enter into that specific actor 
+- the same rules for communications across tasks are true for communication between tasks and actors and between actors
+  - said in other words, actors rely on `Sendable`, too
 
-- occurs when a long-running task runs on the main Actor
-- can cause your app to hang
+- `Actor`s are reference types, but isolate all of their properties and code to prevent concurrent access
+  - all `Actor` types are implicitly `Sendable`
 
-### Actor contention 
+- all Actor instance definitions (properties and functions) are isolated
+  - a child/sub task inherits all attributes of the parent task, therefore, if a task is generated directly by an actor function, said task inherits actor isolation from its context (thus will be able to access the actor properties and call other functions without `await`ing on them
+  - the same is not true for detached tasks, which do not inherit traits from that task’s originating context
+  - Actor properties and functions marked as `nonisolated` are considered to be outside the actor
 
-- occurs when several tasks attempt to use the same `Actor` simultaneously
-- each task must wait for the Actor to become available
-- the `Actor` serializes execution of those tasks
-- hurt performance by reducing parallel execution
-- To fix this, we need make sure that tasks only run on the Actor when they really need exclusive access to the Actor's data. Everything else should run off of the Actor
+### @MainActor
 
-### Thread pool exhaustion
+- represents main thread
+- use it when you need to update UI in your app
+- use the `@MainActor` attribute to indicate that the code must run on the main actor:
 
-- hurt performance by reducing parallel execution
-- can hurt performance or even deadlock an application
-- happens when a task waits for something via a blocking call, such as blocking file or network IO, or acquiring locks, without suspending
-- this breaks the requirement for tasks to make forward progress, because the task continues to occupy the thread where it's executing, but it isn't actually using a CPU core
-- in such situations the concurrency runtime is unable to fully use all CPU cores, and can even cause deadlock
-- make blocking calls outside Swift Concurrency (for example by running it on a Dispatch queue, and bridge it to the concurrency world using continuations)
+```swift
+@MainActor func updateView() { … }
 
-### Continuation misuse
+Task { @MainActor in
+  // update UI here
+}
+```
 
-- occurs when the continuation callback is called multiple times or never
-- the program will crash or misbehave when the continuation callback is called more than once
-- the task will leak (a.k.a. wait forever) if the callback is never called
+- the Swift compiler will guarantee that main-actor-isolated code will only be executed on the main thread
 
-The new Swift Concurrency instrument helps catching these problems in your app.
+- `@MainActor` can also be applied to types, in which case the instances of those types will be isolated to the main actor
+  - properties will be only accessible while on the main actor
+  - methods are isolated to the main actor, unless marked `nonisolated`
+
+```swift
+@MainActor
+class ChickenValley: Sendable {
+  var flock: [Chicken]
+  var food: [Pineapple]
+
+  func advanceTime() {
+    for chicken in flock {
+      chicken.eat(from: &food)
+    }
+  }
+}
+```
+
+## Atomicity
+
+- state can change across `awaits` calls
+- if you're not careful, you can end up with a high-level data race where the program is in an unexpected state, even though the data is not corrupted
+- when writing your actor, think in terms of synchronous, transactional operations that can be interleaved in any way
+- keep async actor operations simple
+
+## Ordering
+
+- Swift Concurrency provides tools for ordering operations
+- actors do no guaranteed FIFO processing
+- actors execute the highest-priority work first
+  - eliminates priority inversions
+  - diffent than serial Dispatch queues, which execute in a strictly FIFO order
+
+Tools for ordering:
+
+- `Task`s
+- `AsyncStream`s deliver elements in order:
+
+```swift
+for await event in eventStream {
+  await process(event)
+}
+```


### PR DESCRIPTION
Hi, I found something weird about this [article](https://www.wwdcnotes.com/notes/wwdc22/110350/).
In this article, the title is "[Visualize and optimize Swift concurrency](https://www.wwdcnotes.com/notes/wwdc22/110350)" but the content is about "[Eliminate data races using Swift Concurrency](https://www.wwdcnotes.com/notes/wwdc22/110351)".
I think two contents have been changed each other.
So I checked GitHub and it seems that the contents of 110350.md and 110351.md have changed.
I think this can be solved by changing the title of the two, so please check it out!