### PR TITLE
Make image ref style consistent and displayable in GitHub web

### DIFF
--- a/content/notes/wwdc23/10104.md
+++ b/content/notes/wwdc23/10104.md
@@ -6,7 +6,7 @@ contributors: rogerluan
 
 Overview of the data flow when requesting Siri to play a song via HomePod:
 
-![][../../../images/notes/wwdc23/10104/dataflow.png]
+![][dataflow]
 
 - The device must be connected to the same network as the HomePod.
 - The device doesn't need to be physically near the person who is speaking.
@@ -20,9 +20,9 @@ Overview of the data flow when requesting Siri to play a song via HomePod:
 
 ## Example requests
 
-![][../../../images/notes/wwdc23/10104/music-and-radio-examples.png]
+![][music-and-radio-examples]
 
-![][../../../images/notes/wwdc23/10104/podcasts-and-audiobooks-examples.png]
+![][podcasts-and-audiobooks-examples]
 
 ## Example code to resolve intents
 
@@ -51,3 +51,7 @@ Make sure your app responds all intents as fast as possible. Requests will timeo
 - [Introducing SiriKit Media Intents - WWDC19](https://wwdcnotes.com/notes/wwdc19/207/)
 - [Expand your SiriKit Media Intents to more platforms - WWDC20](https://wwdcnotes.com/notes/wwdc20/10061/)
 - [Tune up your AirPlay audio experience - WWDC23](https://wwdcnotes.com/notes/wwdc23/10238/)
+
+[dataflow]: ../../../images/notes/wwdc23/10104/dataflow.png
+[music-and-radio-examples]: ../../../images/notes/wwdc23/10104/music-and-radio-examples.png
+[podcasts-and-audiobooks-examples]: ../../../images/notes/wwdc23/10104/podcasts-and-audiobooks-examples.png


### PR DESCRIPTION
Thanks for showing me why this style is preferred over the other one I used @Jeehut 🎉 

<img width="1135" alt="image" src="https://github.com/WWDCNotes/Content/assets/8419048/bae17182-b685-4a7b-b964-157872d87328">
