### PR TITLE
Attempt to fix indentation in website

### DIFF
--- a/content/notes/wwdc23/10120.md
+++ b/content/notes/wwdc23/10120.md
@@ -3,22 +3,22 @@ contributors: rogerluan
 ---
 
 - macOS 14 introduces support to web apps, similar to what was already possible with prior versions of iOS/iPadOS, but better.
-    - Different from iOS/iPadOS, web apps on macOS look and feel like a standalone app, whereas on iOS/iPadOS they are by default merely a shortcut that opens up the default browser (e.g. Safari), functioning more as a homescreen bookmark than anything else.
-    - With iOS/iPadOS 17, you can now customize the disply mode of your web app to make it look and feel more like a standalone app, and not just a shortcut to the default browser.
+  - Different from iOS/iPadOS, web apps on macOS look and feel like a standalone app, whereas on iOS/iPadOS they are by default merely a shortcut that opens up the default browser (e.g. Safari), functioning more as a homescreen bookmark than anything else.
+  - With iOS/iPadOS 17, you can now customize the disply mode of your web app to make it look and feel more like a standalone app, and not just a shortcut to the default browser.
 - When creating/saving a new web app, you can customize its app icon and name, and it gets saved in your dock.
 - Safari copies the cookies so your session is saved. This means that if you're logged in to a website in Safari, you'll be logged in to the same website in the web app too.
-    - Note that only cookies are copied, and not any other type of local storage.
+  - Note that only cookies are copied, and not any other type of local storage.
 - All websites support web apps out of the box without any specific implementation:
-    - There's no Safari toolbar, or tabs, etc, so the view is cleaner.
-    - Supports auto-filling passwords from iCloud Keychain or other 3rd party password managers.
-    - Privacy-minded prompts for location, camera, microphone, etc. work the same way as with native macOS apps.
-    - Supports web notifications, with app icon, sounds, badges, Focus mode.
+  - There's no Safari toolbar, or tabs, etc, so the view is cleaner.
+  - Supports auto-filling passwords from iCloud Keychain or other 3rd party password managers.
+  - Privacy-minded prompts for location, camera, microphone, etc. work the same way as with native macOS apps.
+  - Supports web notifications, with app icon, sounds, badges, Focus mode.
 - Developers can further customize the behavior of web apps to offer a better experience to users:
-    - "Standalone Display Mode"
-        - macOS: it hides the default navigation toolbar.
-        - iOS/iPadOS: it launches as a real "app", and not in the default browser anymore, hiding all the browser-related UI, and with separate cookies and storage from the browser.
-    - You can customize web links behavior within your web app by defining different link scopes. The default scope is your web app's host, so that your own links will open within your app, but other external links should open in the default browser.
-        - If you need to bypass the scope for whatever reason, use `window.open`, which will always bypass the web app's link scope and open the link within the web app.
+  - "Standalone Display Mode"
+    - macOS: it hides the default navigation toolbar.
+    - iOS/iPadOS: it launches as a real "app", and not in the default browser anymore, hiding all the browser-related UI, and with separate cookies and storage from the browser.
+  - You can customize web links behavior within your web app by defining different link scopes. The default scope is your web app's host, so that your own links will open within your app, but other external links should open in the default browser.
+    - If you need to bypass the scope for whatever reason, use `window.open`, which will always bypass the web app's link scope and open the link within the web app.
 
 ## App Manifest
 
@@ -51,9 +51,9 @@ contributors: rogerluan
 
 - Web Push standards. If you already have a web push implementation, it should work out of the box.
 - Sounds:
-    - macOS: off by default.
-    - iOS/iPadOS: on by default.
-    - Override default values by passing `silent: true/false` in your notification payload.
+  - macOS: off by default.
+  - iOS/iPadOS: on by default.
+  - Override default values by passing `silent: true/false` in your notification payload.
 - Managed through system preferences like any native macOS and iOS/iPadOS app.
 - Supports badges.
 - Supports Focus.


### PR DESCRIPTION
## Description

This PR aims to solve this:

code|live
--|--
<img width="350" src="https://github.com/WWDCNotes/Content/assets/8419048/d96ed8c1-32a4-4ba1-9586-4faa9a771889">|<img width="350" src="https://github.com/WWDCNotes/Content/assets/8419048/7fbd3e9a-80bf-4c0b-aee3-6bdaf473d0a5"> 

## Reviewers

@Jeehut could you check whether this works? Perhaps before merging/publishing? I prefer the 4-space indentation for clarity, but if the 2-space one is required, I'd be ok with that :) 

Thanks 🙇 