### PR TITLE
Improve code formatting in "Create accessible spatial experiences"

### DIFF
--- a/content/notes/wwdc23/10034.md
+++ b/content/notes/wwdc23/10034.md
@@ -37,6 +37,7 @@ SwiftUI can be used to build visionOS apps[^1]
 - Label, value, traits[^2]
 - Custom rotors, custom actions, custom content[^3]
 - System actions
+
 ```swift
 // RealityKit AccessibilityComponent API
 
@@ -49,6 +50,7 @@ cloud.components[AccessibilityComponent.self] = accessibilityComponent
 ```
 
 Whenever the app state changes, update the relevant property on the accessibility component
+
 ```swift
 var isHappy: Bool {
   didSet {
@@ -66,11 +68,13 @@ var isHappy: Bool {
 	- App receives hand input
 	- VoiceOver does not process its own gestures
 	- People can choose to run your app in Direct Gesture Mode or Voice Overs default interaction mode
-	- Post announcements that describe the scene 
+	- Post announcements that describe the scene
+
     ```swift 
 	AccessibilityNotification
 	    .Announcement("8 clouds in front of you").post()
     ```
+    
 	- Announce meaningful events
 	- Announce changes in context
 	- Use sounds
@@ -85,6 +89,7 @@ Head anchors
 - Zoom accessibility feature is head anchored
 - **Avoid critical information in head-anchored UI**
 - **NEW** Provide alternatives
+
   ```swift
   // SwiftUI
   @Environment(\.accessibilityPrefersHeadAnchorAlternative)
@@ -106,6 +111,7 @@ Even when motion effects are used subtlety, it can be a jarring experience for s
 - Persistent background effects
 
 Provide alternatives when Reduce Motion is enabled
+
 ```swift
 // SwiftuI
 @Environment(\.accessibilityReduceMotion)
@@ -190,11 +196,13 @@ Quality captions are one of the most impactful things you can do for people with
 - Using these options, people can make their captions easy to see and read
 - If you are not using AVFoundation, implement:
 	- `isClosedCaptioningEnabled` to check whether someone already has Closed Captions enabled in Accessibility settings.
+
 	  ```swift
 	  UlAccessibility.isClosedCaptioningEnabled
 	  UIAccessibility.closedCaptioningStatusDidChangeNotification
       ```
 	- Media Accessibility framework to access each style attribute
+
 	   ```swift
 	  MACaptionAppearanceCopyFontDescriptorForStyle
 	  MACaptionAppearanceCopyForegroundColor


### PR DESCRIPTION
I noticed that some code was treated as inline when rendered, this fix should improve its presentation