### PR TITLE
Formatting for 10309.md

### DIFF
--- a/content/notes/wwdc23/10309.md
+++ b/content/notes/wwdc23/10309.md
@@ -19,6 +19,7 @@ Using a standard layout helps with readability and consistency. There are six [r
 ![Recommended widget layouts][layouts]
 
 Choose a layout based on whether the information to display is
+
 - primarily text (1)
 - primarily text with a colored bar to indicate it is part of a collection, such as color-coded calendar items (2)
 - graphical with supporting text (3 or 4)
@@ -40,7 +41,8 @@ Ideally, circular widgets should display rich information, however they can also
 Complications are tinted based on the color of the watch face. Widgets in the Smart Stack are more flexible.
 
 By default, Smart Stack widgets have a dark material background with white text. The widget background can be dynamic and can aid app recognition or provide information. 
-Examples: 
+Examples:
+
 - The background of the Books widget is the book cover image.
 - The background of the Stocks widget is red or green to indicate performance.
 
@@ -57,6 +59,7 @@ Session control widgets are system-generated and cannot be created by developers
 ### Relevancy
 
 Widgets rise to the top of the Smart Stack based on relevance. Widgets can be prioritized based on
+
 - Time and date. For example, showing an event that is happening in the next hour.
 - Location. For example, showing a reminder when the user reaches home or a specific GPS location.
 - Headphones detection. For example, showing the current audiobook when headphones are connected.


### PR DESCRIPTION
Bulleted lists are rendering fine on github and in my editor (VSCode), but look broken on the WWDCNotes website. I suspect they need a preceding empty line.

<img width="696" alt="Screenshot 2023-07-21 at 7 55 12 am" src="https://github.com/WWDCNotes/Content/assets/37495279/4ab2279a-e992-4a21-b591-1f66e7a069aa">
